### PR TITLE
Correct usage of getSideBar in config to an array of themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,14 @@ import { getSidebar } from 'vitepress-plugin-auto-sidebar'
 
 export default {
   themeConfig: {
-    sidebar: getSidebar({ contentRoot: '/', contentDirs: ['team'], collapsible: true, collapsed: true })
+    sidebar: [
+      getSidebar({
+        contentRoot: "/",
+        contentDirs: ['team'],
+        collapsible: true,
+        collapsed: true,
+      }),
+    ],
   }
 }
 ```


### PR DESCRIPTION
Themes is now an array of objects, and not just one object