### PR TITLE
Add options to customize title of items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.2.0
+
+* Add `useFrontmatter` option to extract titles (by @nandenjin)
+* Accept type `ContentDir` for `options.contentDir` to set custom titles (by @nandenjin)
+
 ## v1.1.0
 
 * Ignore the underscore file (by @ZhongxuYang)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ export default {
   > Boolean whether the first level can be unfolded
 * collapsed – Default: true
   > Boolean whether the first level items are already expanded after loading
-* useFrontMatter - Default: false
+* useFrontmatter - Default: false
   > Boolean whether use front-matter for title of items
 
 **Tips：** If you want to ignore a file, name the `.md` file with an underscore ( `_` ).

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export default {
 * useFrontmatter - Default: false
   > Boolean whether use front-matter for title of items
 
-**Tips：** If you want to ignore a file, name the `.md` file with an underscore ( `_` ).
+**Tips:** If you want to ignore a file, name the `.md` file with an underscore (`_`).
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -40,11 +40,13 @@ export default {
 * contentRoot – Default: '/'
   > String Root of your VitePress Docs
 * contentDirs – Default: ['/']
-  > Array of indexable contentRoot dirs, if you want to include seperatly
+  > Array of indexable contentRoot dirs, if you want to include seperatly. Accepts `string[]` or `{ path: string, title?: string }[]`
 * collapsible – Default: true
   > Boolean whether the first level can be unfolded
 * collapsed – Default: true
   > Boolean whether the first level items are already expanded after loading
+* useFrontMatter - Default: false
+  > Boolean whether use front-matter for title of items
 
 **Tips：** If you want to ignore a file, name the `.md` file with an underscore ( `_` ).
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export default {
 * contentRoot – Default: '/'
   > String Root of your VitePress Docs
 * contentDirs – Default: ['/']
-  > Array of indexable contentRoot dirs, if you want to include seperatly. Accepts `string[]` or `{ path: string, title?: string }[]`
+  > Array of indexable contentRoot dirs, if you want to include separately. Accepts `string[]` or `{ path: string, title?: string }[]`
 * collapsible – Default: true
   > Boolean whether the first level can be unfolded
 * collapsed – Default: true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "vitepress-plugin-auto-sidebar",
-  "version": "1.0.7",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitepress-plugin-auto-sidebar",
-      "version": "1.0.7",
+      "version": "1.1.0",
       "license": "MIT",
+      "dependencies": {
+        "front-matter": "^4.0.2"
+      },
       "devDependencies": {
         "@types/node": "^18.16.16",
         "vite": "^4.3.9",
@@ -531,6 +534,14 @@
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
       "dev": true
     },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -589,11 +600,31 @@
         "@esbuild/win32-x64": "0.17.19"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "node_modules/front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "dependencies": {
+        "js-yaml": "^3.13.1"
+      }
     },
     "node_modules/fsevents": {
       "version": "2.3.2",
@@ -616,6 +647,18 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/lru-cache": {
@@ -754,6 +797,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "node_modules/typescript": {
       "version": "4.9.5",
@@ -1156,6 +1204,14 @@
       "integrity": "sha512-7OjdcV8vQ74eiz1TZLzZP4JwqM5fA94K6yntPS5Z25r9HDuGNzaGdgvwKYq6S+MxwF0TFRwe50fIR/MYnakdkQ==",
       "dev": true
     },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1207,11 +1263,24 @@
         "@esbuild/win32-x64": "0.17.19"
       }
     },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+    },
     "estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
+    },
+    "front-matter": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/front-matter/-/front-matter-4.0.2.tgz",
+      "integrity": "sha512-I8ZuJ/qG92NWX8i5x1Y8qyj3vizhXS31OxjKDu3LKP+7/qBgfIKValiZIEwoVoJKUHlhWtYrktkxV1XsX+pPlg==",
+      "requires": {
+        "js-yaml": "^3.13.1"
+      }
     },
     "fsevents": {
       "version": "2.3.2",
@@ -1225,6 +1294,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -1305,6 +1383,11 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
     },
     "typescript": {
       "version": "4.9.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vitepress-plugin-auto-sidebar",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vitepress-plugin-auto-sidebar",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "front-matter": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vitepress-plugin-auto-sidebar",
   "repository": "git://github.com/JonathanSchndr/vitepress-plugin-auto-sidebar.git",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Generate the VitePress sidebar through the folder structure.",
   "types": "./dist/types/src/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,5 +37,8 @@
     "@types/node": "^18.16.16",
     "vite": "^4.3.9",
     "vue-tsc": "^1.6.5"
+  },
+  "dependencies": {
+    "front-matter": "^4.0.2"
   }
 }

--- a/playground/docs/.vitepress/config.ts
+++ b/playground/docs/.vitepress/config.ts
@@ -14,9 +14,16 @@ export default defineConfig({
     ],
     sidebar: getSidebar({
       contentRoot: '/docs',
-      contentDirs: ['team'],
-      collapsible: true,
+      contentDirs: [
+        'team', // Just a path for directory
+        {
+          path: 'project',
+          title: 'About Project' // Customize title
+        }
+      ],
+      collapsible: false,
       collapsed: true,
+      useFrontmatter: true
     }) as any,
   },
 });

--- a/playground/docs/project/index.md
+++ b/playground/docs/project/index.md
@@ -1,0 +1,7 @@
+---
+title: About This Project
+---
+
+# Project
+
+This page contains frontmatter section so the title and sidebar text are customized!

--- a/playground/docs/project/index.md
+++ b/playground/docs/project/index.md
@@ -4,4 +4,4 @@ title: About This Project
 
 # Project
 
-This page contains frontmatter section so the title and sidebar text are customized!
+This page contains a frontmatter section, so the title and sidebar text are customized!

--- a/playground/package-lock.json
+++ b/playground/package-lock.json
@@ -15,8 +15,11 @@
       }
     },
     "..": {
-      "version": "1.0.7",
+      "version": "1.2.0",
       "license": "MIT",
+      "dependencies": {
+        "front-matter": "^4.0.2"
+      },
       "devDependencies": {
         "@types/node": "^18.16.16",
         "vite": "^4.3.9",
@@ -2016,6 +2019,7 @@
       "version": "file:..",
       "requires": {
         "@types/node": "^18.16.16",
+        "front-matter": "^4.0.2",
         "vite": "^4.3.9",
         "vue-tsc": "^1.6.5"
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { Options } from "./types";
 
 import fs from "fs";
 import path from "path";
+import frontMatter from "front-matter";
 
 function getSidebarItems(dir: string[], currentRoot: string | undefined, root: string | undefined, options: Options): object[] {
 	return dir
@@ -18,8 +19,17 @@ function getSidebarItems(dir: string[], currentRoot: string | undefined, root: s
           items
         } : null!;
       } else if (e.endsWith('.md') && e[0] !== '_') {
+        let title: string | undefined;
+
+        if (options.useFrontMatter) {
+          const fm = frontMatter<{title: string}>(fs.readFileSync(path.resolve(currentRoot ?? '/', e), {encoding: 'utf-8'}));
+          if (fm) {
+            title = fm.attributes.title;
+          }
+        }
+
         return {
-          text: ((e.charAt(0).toUpperCase() + e.slice(1)).slice(0, -3)).replaceAll('-', ' '),
+          text: title || ((e.charAt(0).toUpperCase() + e.slice(1)).slice(0, -3)).replaceAll('-', ' '),
           link: childDir.replace(root ?? '', '')
         };
       }
@@ -33,6 +43,7 @@ export function getSidebar(options: Options = {}) {
   options.contentDirs = options?.contentDirs?.length ? options.contentDirs : ['/'];
   options.collapsible = options?.collapsible ?? true;
   options.collapsed = options?.collapsed ?? true;
+  options.useFrontMatter = options?.useFrontMatter ?? false;
 
 	options.contentRoot = path.join(process.cwd(), options.contentRoot)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,31 @@
-import { Options } from "./types";
+import { ContentDir, Options } from "./types";
 
 import fs from "fs";
 import path from "path";
 import frontMatter from "front-matter";
 
-function getSidebarItems(dir: string[], currentRoot: string | undefined, root: string | undefined, options: Options): object[] {
+function getSidebarItems(dir: string[] | ContentDir[], currentRoot: string | undefined, root: string | undefined, options: Options): object[] {
 	return dir
-    .filter(e => e.endsWith('.md') || fs.statSync(path.resolve(currentRoot ?? '/', e)).isDirectory())
-    .map((e: string) => {
+    .filter(e => {
+      const itemPath = typeof e === 'string' ? e : e.path
+      return (itemPath.endsWith('.md') || fs.statSync(path.resolve(currentRoot ?? '/', itemPath)).isDirectory())
+    })
+    .map((entry: string | ContentDir) => {
+      const e = typeof entry === 'string' ? entry : entry.path;
       const childDir = path.resolve(currentRoot ?? '/', e);
       if (fs.statSync(childDir).isDirectory()) {
         const items = getSidebarItems(fs.readdirSync(childDir), childDir, root, options)
         const fileName = e.split('/').pop() ?? ''
+        
+        let title: string;
+        if (typeof entry !== 'string' && entry.title) {
+          title = entry.title
+        } else {
+          title = ((fileName.charAt(0).toUpperCase() + fileName.slice(1))).replaceAll('-', ' ')
+        }
+
         return items.length ?  {
-          text: ((fileName.charAt(0).toUpperCase() + fileName.slice(1))).replaceAll('-', ' '),
+          text: title,
           collapsible: options.collapsible,
           collapsed: options.collapsed,
           items

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ function getSidebarItems(dir: string[] | ContentDir[], currentRoot: string | und
       if (fs.statSync(childDir).isDirectory()) {
         const items = getSidebarItems(fs.readdirSync(childDir), childDir, root, options)
         const fileName = e.split('/').pop() ?? ''
-        
+
         let title: string;
         if (typeof entry !== 'string' && entry.title) {
           title = entry.title
@@ -33,7 +33,7 @@ function getSidebarItems(dir: string[] | ContentDir[], currentRoot: string | und
       } else if (e.endsWith('.md') && e[0] !== '_') {
         let title: string | undefined;
 
-        if (options.useFrontMatter) {
+        if (options.useFrontmatter) {
           const fm = frontMatter<{title: string}>(fs.readFileSync(path.resolve(currentRoot ?? '/', e), {encoding: 'utf-8'}));
           if (fm) {
             title = fm.attributes.title;
@@ -55,7 +55,7 @@ export function getSidebar(options: Options = {}) {
   options.contentDirs = options?.contentDirs?.length ? options.contentDirs : ['/'];
   options.collapsible = options?.collapsible ?? true;
   options.collapsed = options?.collapsed ?? true;
-  options.useFrontMatter = options?.useFrontMatter ?? false;
+  options.useFrontmatter = options?.useFrontmatter ?? false;
 
 	options.contentRoot = path.join(process.cwd(), options.contentRoot)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import path from "path";
 import frontMatter from "front-matter";
 
-function getSidebarItems(dir: string[] | ContentDir[], currentRoot: string | undefined, root: string | undefined, options: Options): object[] {
+function getSidebarItems(dir: (string | ContentDir)[], currentRoot: string | undefined, root: string | undefined, options: Options): object[] {
 	return dir
     .filter(e => {
       const itemPath = typeof e === 'string' ? e : e.path
@@ -32,7 +32,7 @@ function getSidebarItems(dir: string[] | ContentDir[], currentRoot: string | und
         } : null!;
       } else if (e.endsWith('.md') && e[0] !== '_') {
         let title: string | undefined;
-
+        
         if (options.useFrontmatter) {
           const fm = frontMatter<{title: string}>(fs.readFileSync(path.resolve(currentRoot ?? '/', e), {encoding: 'utf-8'}));
           if (fm) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,7 @@ export interface Options {
   contentDirs?: string[] | ContentDir[] | null;
   collapsible?: boolean;
   collapsed?: boolean;
-  useFrontMatter?: boolean;
+  useFrontmatter?: boolean;
 }
 
 export interface ContentDir {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,12 @@
 export interface Options {
   contentRoot?: string;
-  contentDirs?: string[] | null;
+  contentDirs?: string[] | ContentDir[] | null;
   collapsible?: boolean;
   collapsed?: boolean;
   useFrontMatter?: boolean;
+}
+
+export interface ContentDir {
+  path: string,
+  title?: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 export interface Options {
   contentRoot?: string;
-  contentDirs?: string[] | ContentDir[] | null;
+  contentDirs?: (string | ContentDir)[] | null;
   collapsible?: boolean;
   collapsed?: boolean;
   useFrontmatter?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,4 +3,5 @@ export interface Options {
   contentDirs?: string[] | null;
   collapsible?: boolean;
   collapsed?: boolean;
+  useFrontMatter?: boolean;
 }


### PR DESCRIPTION
## Changes

### Add `useFrontmatter` option

Reads markdown contents and extract title by using [`front-matter`](https://www.npmjs.com/package/front-matter)

### Accept new type `ContentDir` for `options.contentDirs`

Now we can set title for each of contentDirs.

```typescript
interface ContentDir {
  path: string
  title?: string
}
```

## Motivation

I'm a Japanese developer and I believe it is useful for non-latin language users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a `useFrontmatter` configuration option to enable front-matter usage for item titles in VitePress Docs.
	- Added support for custom titles through the `ContentDir` type in sidebar configurations.
- **Documentation**
	- Updated README and CHANGELOG to reflect the new features and improvements.
- **Dependencies**
	- Added `front-matter` as a new dependency to enhance title extraction capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->