### PR TITLE
fix: playground build bundling

### DIFF
--- a/playground/docs/.vitepress/config.ts
+++ b/playground/docs/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress';
 import { getSidebar } from 'vitepress-plugin-auto-sidebar';
 import { fileURLToPath } from 'url';
-import { dirname, resolve } from 'path';
+import { dirname, resolve } from 'node:path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { ContentDir, Options, SidebarItem } from './types';
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import matter from 'gray-matter';
 
 const MD_EXTENSION = '.md';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import path from 'path'
+import path from 'node:path'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
@@ -8,7 +8,7 @@ export default defineConfig({
       name: "AutoSidebar"
     },
     rollupOptions: {
-      external: ["fs", "path"],
+      external: ['node:fs', 'node:path'],
     },
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vitest/config';
-import path from 'path';
+import path from 'node:path';
 
 export default defineConfig({
   poolOptions: {


### PR DESCRIPTION
VitePress was failing to load the playground config because the published ESM bundle pulled in Node builtins through a `require` path. This change keeps the library bundle import-based so the config can be evaluated in VitePress without tripping Rolldown's CJS handling.

## What changed
- Switched internal Node builtin imports to `node:fs` and `node:path`
- Kept the Vite and Vitest configs aligned with the same `node:` specifiers
- Updated the playground VitePress config to use `node:path`

## Notes
- The fix is intentionally small and focused on the bundling boundary that caused the playground build to fail.
- No behavior changes to the sidebar generation logic itself.